### PR TITLE
Added Endpoints for Remaining tables.

### DIFF
--- a/Manner.Api/Manner.Api/Controllers/MannerController.cs
+++ b/Manner.Api/Manner.Api/Controllers/MannerController.cs
@@ -5,6 +5,7 @@ using Manner.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations; // Add this namespace for Swagger annotations
 using System.Data.SqlTypes;
 
 namespace Manner.Api.Controllers
@@ -15,45 +16,441 @@ namespace Manner.Api.Controllers
     public class MannerController : ControllerBase
     {
         private readonly ILogger<MannerController> _logger;
+        private readonly IIncorporationDelayService _incorporationDelayService;
+        private readonly IManureGroupService _manureGroupService;
+        private readonly IManureTypeCategoryService _manureTypeCategoryService;
+        private readonly IManureTypeService _manureTypeService;
+        private readonly IMoistureTypeService _moistureTypeService;
+        private readonly IRainTypeService _rainTypeService;
+        private readonly ISubSoilService _subSoilService;
+        private readonly ITopSoilService _topSoilService;
+        private readonly IWindspeedService _windspeedService;
         private readonly IClimateService _climateService;
         private readonly IApplicationMethodService _applicationMethodService;
+        private readonly ICountryService _countryService;
         private readonly ICropTypeService _cropTypeService;
+        private readonly IIncorporationMethodService _incorporationMethodService;
 
-
-        public MannerController(ILogger<MannerController> logger, 
-            IClimateService climateService, 
+        public MannerController(ILogger<MannerController> logger,
+            IClimateService climateService,
             IApplicationMethodService applicationMethodService,
-            ICropTypeService cropTypeService)
+            ICountryService countryService,
+            ICropTypeService cropTypeService,
+            IIncorporationMethodService incorporationMethodService,
+            IIncorporationDelayService incorporationDelayService,
+            IManureGroupService manureGroupService,
+            IManureTypeCategoryService manureTypeCategoryService,
+            IManureTypeService manureTypeService,
+            IMoistureTypeService moistureTypeService,
+            IRainTypeService rainTypeService,
+            ISubSoilService subSoilService,
+            ITopSoilService topSoilService,
+            IWindspeedService windspeedService)
         {
             _logger = logger;
+            _incorporationDelayService = incorporationDelayService;
+            _manureGroupService = manureGroupService;
+            _manureTypeCategoryService = manureTypeCategoryService;
+            _manureTypeService = manureTypeService;
+            _moistureTypeService = moistureTypeService;
+            _rainTypeService = rainTypeService;
+            _subSoilService = subSoilService;
+            _topSoilService = topSoilService;
+            _windspeedService = windspeedService;
             _climateService = climateService;
             _applicationMethodService = applicationMethodService;
+            _countryService = countryService;
             _cropTypeService = cropTypeService;
+            _incorporationMethodService = incorporationMethodService;
         }
-         
+
         [HttpGet("climates/{postcode}")]
+        [SwaggerOperation(Summary = "Retrieve climate data by postcode", Description = "Fetches climate information for a given postcode.")]
+        [ProducesResponseType(typeof(ClimateDto), 200)]
+        [ProducesResponseType(404)]
         public async Task<ActionResult<ClimateDto?>> Climates(string postcode)
-        {           
-            return Ok(await _climateService.FetchByPostcodeAsync(postcode));
+        {
+            var climate = await _climateService.FetchByPostcodeAsync(postcode);
+            if (climate == null)
+            {
+                return NotFound();
+            }
+            return Ok(climate);
         }
 
         [HttpGet("application-methods")]
+        [SwaggerOperation(Summary = "Retrieve all application methods", Description = "Fetches a list of all application methods available.")]
+        [ProducesResponseType(typeof(IEnumerable<ApplicationMethodDto>), 200)]
         public async Task<ActionResult<IEnumerable<ApplicationMethodDto>?>> ApplicationMethods()
-        {            
+        {
             return Ok(await _applicationMethodService.FetchAllAsync());
         }
 
+        [HttpGet("application-methods/{id}")]
+        [SwaggerOperation(Summary = "Retrieve application method by ID", Description = "Fetches a specific application method by its unique ID.")]
+        [ProducesResponseType(typeof(ApplicationMethodDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ApplicationMethodDto>?> ApplicationMethods(int id)
+        {
+            var method = await _applicationMethodService.FetchByIdAsync(id);
+            if (method == null)
+            {
+                return NotFound();
+            }
+            return Ok(method);
+        }
+
         [HttpGet("crop-types")]
+        [SwaggerOperation(Summary = "Retrieve all crop types", Description = "Fetches a list of all crop types available.")]
+        [ProducesResponseType(typeof(IEnumerable<CropTypeDto>), 200)]
         public async Task<ActionResult<IEnumerable<CropTypeDto>?>> CropTypes()
         {
             return Ok(await _cropTypeService.FetchAllAsync());
         }
 
-        //Get Autumn Crop Nitrogen Uptake
+        [HttpGet("crop-types/{id}")]
+        [SwaggerOperation(Summary = "Retrieve crop type by ID", Description = "Fetches a specific crop type by its unique ID.")]
+        [ProducesResponseType(typeof(CropTypeDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<CropTypeDto>?> CropTypes(int id)
+        {
+            var cropType = await _cropTypeService.FetchByIdAsync(id);
+            if (cropType == null)
+            {
+                return NotFound();
+            }
+            return Ok(cropType);
+        }
+
+        [HttpGet("countries")]
+        [SwaggerOperation(Summary = "Retrieve all countries", Description = "Fetches a list of all countries available.")]
+        [ProducesResponseType(typeof(IEnumerable<CountryDto>), 200)]
+        public async Task<ActionResult<IEnumerable<CountryDto>?>> Countries()
+        {
+            return Ok(await _countryService.FetchAllAsync());
+        }
+
+        [HttpGet("countries/{id}")]
+        [SwaggerOperation(Summary = "Retrieve country by ID", Description = "Fetches a specific country by its unique ID.")]
+        [ProducesResponseType(typeof(CountryDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<CountryDto>?> Countries(int id)
+        {
+            var country = await _countryService.FetchByIdAsync(id);
+            if (country == null)
+            {
+                return NotFound();
+            }
+            return Ok(country);
+        }
+
         [HttpPost("autumn-crop-nitrogen-uptake")]
+        [SwaggerOperation(Summary = "Get Autumn Crop Nitrogen Uptake", Description = "Calculates and retrieves the nitrogen uptake for autumn crops based on the provided request data.")]
+        [ProducesResponseType(typeof(AutumnCropNitrogenUptakeResponse), 200)]
         public async Task<ActionResult<AutumnCropNitrogenUptakeResponse>> GetAutumnCropNitrogenUptake(AutumnCropNitrogenUptakeRequest autumnCropNitrogenUptakeRequest)
         {
             return Ok(await _cropTypeService.FetchCropUptakeFactorDefault(autumnCropNitrogenUptakeRequest));
         }
+
+        [HttpGet("incorporation-delays")]
+        [SwaggerOperation(Summary = "Retrieve all incorporation delays", Description = "Fetches a list of all incorporation delays available.")]
+        [ProducesResponseType(typeof(IEnumerable<IncorporationDelayDto>), 200)]
+        public async Task<ActionResult<IEnumerable<IncorporationDelayDto>?>> IncorporationDelays()
+        {
+            var delays = await _incorporationDelayService.FetchAllAsync();
+            return Ok(delays);
+        }
+
+        [HttpGet("incorporation-delays/{id}")]
+        [SwaggerOperation(Summary = "Retrieve incorporation delay by ID", Description = "Fetches a specific incorporation delay by its unique ID.")]
+        [ProducesResponseType(typeof(IncorporationDelayDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<IncorporationDelayDto?>> IncorporationDelays(int id)
+        {
+            var delay = await _incorporationDelayService.FetchByIdAsync(id);
+            if (delay == null)
+            {
+                return NotFound();
+            }
+            return Ok(delay);
+        }
+
+        [HttpGet("incorporation-delays/by-incorp-method/{methodId}")]
+        [SwaggerOperation(Summary = "Retrieve incorporation delays by incorporation method ID", Description = "Fetches incorporation delays associated with a specific incorporation method.")]
+        [ProducesResponseType(typeof(IEnumerable<IncorporationDelayDto>), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<IEnumerable<IncorporationDelayDto>?>> IncorporationDelaysByMethod(int methodId)
+        {
+            var delays = await _incorporationDelayService.FetchByIncorpMethodIdAsync(methodId);
+            if (delays == null || !delays.Any())
+            {
+                return NotFound();
+            }
+            return Ok(delays);
+        }
+
+        [HttpGet("incorporation-methods")]
+        [SwaggerOperation(Summary = "Retrieve all incorporation methods", Description = "Fetches a list of all incorporation methods available.")]
+        [ProducesResponseType(typeof(IEnumerable<IncorporationMethodDto>), 200)]
+        public async Task<ActionResult<IEnumerable<IncorporationMethodDto>?>> IncorporationMethods()
+        {
+            var methods = await _incorporationMethodService.FetchAllAsync();
+            return Ok(methods);
+        }
+
+        [HttpGet("incorporation-methods/{id}")]
+        [SwaggerOperation(Summary = "Retrieve incorporation method by ID", Description = "Fetches a specific incorporation method by its unique ID.")]
+        [ProducesResponseType(typeof(IncorporationMethodDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<IncorporationMethodDto?>> IncorporationMethods(int id)
+        {
+            var method = await _incorporationMethodService.FetchByIdAsync(id);
+            if (method == null)
+            {
+                return NotFound();
+            }
+            return Ok(method);
+        }
+
+        [HttpGet("incorporation-methods/by-app-method/{methodId}")]
+        [SwaggerOperation(Summary = "Retrieve incorporation methods by application method ID", Description = "Fetches incorporation methods associated with a specific application method ID.")]
+        [ProducesResponseType(typeof(IEnumerable<IncorporationMethodDto>), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<IEnumerable<IncorporationMethodDto>?>> IncorporationMethodsByMethodId(int methodId)
+        {
+            var methods = await _incorporationMethodService.FetchByAppMethodIdAsync(methodId);
+            if (methods == null || !methods.Any())
+            {
+                return NotFound();
+            }
+            return Ok(methods);
+        }
+
+        [HttpGet("manure-groups")]
+        [SwaggerOperation(Summary = "Retrieve all manure groups", Description = "Fetches a list of all manure groups available.")]
+        [ProducesResponseType(typeof(IEnumerable<ManureGroupDto>), 200)]
+        public async Task<ActionResult<IEnumerable<ManureGroupDto>?>> ManureGroups()
+        {
+            var groups = await _manureGroupService.FetchAllAsync();
+            return Ok(groups);
+        }
+
+        [HttpGet("manure-groups/{id}")]
+        [SwaggerOperation(Summary = "Retrieve manure group by ID", Description = "Fetches a specific manure group by its unique ID.")]
+        [ProducesResponseType(typeof(ManureGroupDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ManureGroupDto?>> ManureGroups(int id)
+        {
+            var group = await _manureGroupService.FetchByIdAsync(id);
+            if (group == null)
+            {
+                return NotFound();
+            }
+            return Ok(group);
+        }
+
+        [HttpGet("manure-types")]
+        [SwaggerOperation(
+            Summary = "Retrieve all manure types or filter by criteria",
+            Description = "Fetches all manure types if no filters are provided. You can filter by optional parameters such as manureGroupId, manureTypeCategoryId, countryId, highReadilyAvailableNitrogen, and isLiquid."
+        )]
+        [ProducesResponseType(typeof(IEnumerable<ManureTypeDto>), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<IEnumerable<ManureTypeDto>?>> ManureTypes(
+            [FromQuery, SwaggerParameter("ID of the manure group to filter by", Required = false)] int? manureGroupId = null,
+            [FromQuery, SwaggerParameter("ID of the manure type category to filter by", Required = false)] int? manureTypeCategoryId = null,
+            [FromQuery, SwaggerParameter("ID of the country to filter by", Required = false)] int? countryId = null,
+            [FromQuery, SwaggerParameter("Whether to filter by highly readily available nitrogen (true/false)", Required = false)] bool? highReadilyAvailableNitrogen = null,
+            [FromQuery, SwaggerParameter("Whether to filter by liquid manure types (true/false)", Required = false)] bool? isLiquid = null)
+        {
+            IEnumerable<ManureTypeDto>? manureTypes;
+
+            if (!manureGroupId.HasValue && !manureTypeCategoryId.HasValue && !countryId.HasValue &&
+                !highReadilyAvailableNitrogen.HasValue && !isLiquid.HasValue)
+            {
+                // No filters provided, return all manure types
+                manureTypes = await _manureTypeService.FetchAllAsync();
+            }
+            else
+            {
+                // Filters provided, apply them
+                manureTypes = await _manureTypeService.FetchByCriteriaAsync(
+                    manureGroupId,
+                    manureTypeCategoryId,
+                    countryId,
+                    highReadilyAvailableNitrogen,
+                    isLiquid
+                );
+            }
+
+            if (manureTypes == null || !manureTypes.Any())
+            {
+                return NotFound("No manure types found matching the specified criteria.");
+            }
+
+            return Ok(manureTypes);
+        }
+
+
+        [HttpGet("manure-types/{id}")]
+        [SwaggerOperation(Summary = "Retrieve manure type by ID", Description = "Fetches a specific manure type by its unique ID.")]
+        [ProducesResponseType(typeof(ManureTypeDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ManureTypeDto?>> ManureTypes(int id)
+        {
+            var type = await _manureTypeService.FetchByIdAsync(id);
+            if (type == null)
+            {
+                return NotFound($"Manure type with ID {id} not found.");
+            }
+            return Ok(type);
+        }
+
+
+        [HttpGet("manure-type-categories")]
+        [SwaggerOperation(Summary = "Retrieve all manure type categories", Description = "Fetches a list of all manure type categories available.")]
+        [ProducesResponseType(typeof(IEnumerable<ManureTypeCategoryDto>), 200)]
+        public async Task<ActionResult<IEnumerable<ManureTypeCategoryDto>?>> ManureTypeCategories()
+        {
+            var categories = await _manureTypeCategoryService.FetchAllAsync();
+            return Ok(categories);
+        }
+
+        [HttpGet("manure-type-categories/{id}")]
+        [SwaggerOperation(Summary = "Retrieve manure type category by ID", Description = "Fetches a specific manure type category by its unique ID.")]
+        [ProducesResponseType(typeof(ManureTypeCategoryDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ManureTypeCategoryDto?>> ManureTypeCategories(int id)
+        {
+            var category = await _manureTypeCategoryService.FetchByIdAsync(id);
+            if (category == null)
+            {
+                return NotFound();
+            }
+            return Ok(category);
+        }
+
+        [HttpGet("moisture-types")]
+        [SwaggerOperation(Summary = "Retrieve all moisture types", Description = "Fetches a list of all moisture types available.")]
+        [ProducesResponseType(typeof(IEnumerable<MoistureTypeDto>), 200)]
+        public async Task<ActionResult<IEnumerable<MoistureTypeDto>?>> MoistureTypes()
+        {
+            var types = await _moistureTypeService.FetchAllAsync();
+            return Ok(types);
+        }
+
+        [HttpGet("moisture-types/{id}")]
+        [SwaggerOperation(Summary = "Retrieve moisture type by ID", Description = "Fetches a specific moisture type by its unique ID.")]
+        [ProducesResponseType(typeof(MoistureTypeDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<MoistureTypeDto?>> MoistureTypes(int id)
+        {
+            var type = await _moistureTypeService.FetchByIdAsync(id);
+            if (type == null)
+            {
+                return NotFound();
+            }
+            return Ok(type);
+        }
+
+        [HttpGet("rain-types")]
+        [SwaggerOperation(Summary = "Retrieve all rain types", Description = "Fetches a list of all rain types available.")]
+        [ProducesResponseType(typeof(IEnumerable<RainTypeDto>), 200)]
+        public async Task<ActionResult<IEnumerable<RainTypeDto>?>> RainTypes()
+        {
+            var types = await _rainTypeService.FetchAllAsync();
+            return Ok(types);
+        }
+
+        [HttpGet("rain-types/{id}")]
+        [SwaggerOperation(Summary = "Retrieve rain type by ID", Description = "Fetches a specific rain type by its unique ID.")]
+        [ProducesResponseType(typeof(RainTypeDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<RainTypeDto?>> RainTypes(int id)
+        {
+            var type = await _rainTypeService.FetchByIdAsync(id);
+            if (type == null)
+            {
+                return NotFound();
+            }
+            return Ok(type);
+        }
+
+        [HttpGet("sub-soils")]
+        [SwaggerOperation(Summary = "Retrieve all sub-soils", Description = "Fetches a list of all sub-soils available.")]
+        [ProducesResponseType(typeof(IEnumerable<SubSoilDto>), 200)]
+        public async Task<ActionResult<IEnumerable<SubSoilDto>?>> SubSoils()
+        {
+            var soils = await _subSoilService.FetchAllAsync();
+            return Ok(soils);
+        }
+
+        [HttpGet("sub-soils/{id}")]
+        [SwaggerOperation(Summary = "Retrieve sub-soil by ID", Description = "Fetches a specific sub-soil by its unique ID.")]
+        [ProducesResponseType(typeof(SubSoilDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<SubSoilDto?>> SubSoils(int id)
+        {
+            var soil = await _subSoilService.FetchByIdAsync(id);
+            if (soil == null)
+            {
+                return NotFound();
+            }
+            return Ok(soil);
+        }
+
+        [HttpGet("top-soils")]
+        [SwaggerOperation(Summary = "Retrieve all top-soils", Description = "Fetches a list of all top-soils available.")]
+        [ProducesResponseType(typeof(IEnumerable<TopSoilDto>), 200)]
+        public async Task<ActionResult<IEnumerable<TopSoilDto>?>> TopSoils()
+        {
+            var soils = await _topSoilService.FetchAllAsync();
+            return Ok(soils);
+        }
+
+        [HttpGet("top-soils/{id}")]
+        [SwaggerOperation(Summary = "Retrieve top-soil by ID", Description = "Fetches a specific top-soil by its unique ID.")]
+        [ProducesResponseType(typeof(TopSoilDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<TopSoilDto?>> TopSoils(int id)
+        {
+            var soil = await _topSoilService.FetchByIdAsync(id);
+            if (soil == null)
+            {
+                return NotFound();
+            }
+            return Ok(soil);
+        }
+
+        [HttpGet("windspeeds")]
+        [SwaggerOperation(Summary = "Retrieve all windspeeds", Description = "Fetches a list of all windspeeds available.")]
+        [ProducesResponseType(typeof(IEnumerable<WindspeedDto>), 200)]
+        public async Task<ActionResult<IEnumerable<WindspeedDto>?>> Windspeeds()
+        {
+            var windspeeds = await _windspeedService.FetchAllAsync();
+            return Ok(windspeeds);
+        }
+
+        [HttpGet("windspeeds/{id}")]
+        [SwaggerOperation(Summary = "Retrieve windspeed by ID", Description = "Fetches a specific windspeed by its unique ID.")]
+        [ProducesResponseType(typeof(WindspeedDto), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<WindspeedDto?>> Windspeeds(int id)
+        {
+            var windspeed = await _windspeedService.FetchByIdAsync(id);
+            if (windspeed == null)
+            {
+                return NotFound();
+            }
+            return Ok(windspeed);
+        }
+
+
+
+
+
+
+
+
     }
 }

--- a/Manner.Api/Manner.Api/Manner.Api.csproj
+++ b/Manner.Api/Manner.Api/Manner.Api.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Manner.Api/Manner.Api/Program.cs
+++ b/Manner.Api/Manner.Api/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddSwaggerGen(c =>
         new List<string>()
        }
      });
+    c.EnableAnnotations();
 });
 
 builder.Services.RegisterServices(builder.Configuration);

--- a/Manner.Api/Manner.Application/Interfaces/IIncorporationDelayService.cs
+++ b/Manner.Api/Manner.Application/Interfaces/IIncorporationDelayService.cs
@@ -4,4 +4,5 @@ namespace Manner.Application.Interfaces;
 
 public interface IIncorporationDelayService : IService<IncorporationDelayDto>
 {
+    Task<IEnumerable<IncorporationDelayDto>?> FetchByIncorpMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Application/Interfaces/IIncorporationMethodService.cs
+++ b/Manner.Api/Manner.Application/Interfaces/IIncorporationMethodService.cs
@@ -1,6 +1,8 @@
 ﻿using Manner.Application.DTOs;
+
 namespace Manner.Application.Interfaces;
 
 public interface IIncorporationMethodService : IService<IncorporationMethodDto>
 {
+    Task<IEnumerable<IncorporationMethodDto>?> FetchByAppMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Application/Interfaces/IManureTypeService.cs
+++ b/Manner.Api/Manner.Application/Interfaces/IManureTypeService.cs
@@ -1,6 +1,8 @@
 ﻿using Manner.Application.DTOs;
+
 namespace Manner.Application.Interfaces;
 
 public interface IManureTypeService : IService<ManureTypeDto>
 {
+    Task<IEnumerable<ManureTypeDto>?> FetchByCriteriaAsync(int? manureGroupId = null, int? manureTypeCategoryId = null, int? countryId = null, bool? highReadilyAvailableNitrogen = null, bool? isLiquid = null);
 }

--- a/Manner.Api/Manner.Application/Services/IncorporationDelayService.cs
+++ b/Manner.Api/Manner.Application/Services/IncorporationDelayService.cs
@@ -28,4 +28,10 @@ public class IncorporationDelayService : IIncorporationDelayService
     {
         return _mapper.Map<IncorporationDelayDto>(await _incorporationDelayRepository.FetchByIdAsync(id));
     }
+
+    public async Task<IEnumerable<IncorporationDelayDto>?> FetchByIncorpMethodIdAsync(int methodId)
+    {
+        var delays = await _incorporationDelayRepository.FetchByIncorpMethodIdAsync(methodId);
+        return _mapper.Map<IEnumerable<IncorporationDelayDto>>(delays);
+    }
 }

--- a/Manner.Api/Manner.Application/Services/IncorporationMethodService.cs
+++ b/Manner.Api/Manner.Application/Services/IncorporationMethodService.cs
@@ -5,27 +5,39 @@ using Manner.Core.Attributes;
 using Manner.Core.Entities;
 using Manner.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace Manner.Application.Services;
-
-[Service(ServiceLifetime.Transient)]
-public class IncorporationMethodService : IIncorporationMethodService
+namespace Manner.Application.Services
 {
-    private readonly IIncorporationMethodRepository _incorporationMethodRepository;
-    private readonly IMapper _mapper;
-    public IncorporationMethodService(IIncorporationMethodRepository incorporationMethodRepository, IMapper mapper)
+    [Service(ServiceLifetime.Transient)]
+    public class IncorporationMethodService : IIncorporationMethodService
     {
-        _incorporationMethodRepository = incorporationMethodRepository;
-        _mapper = mapper;
-    }
+        private readonly IIncorporationMethodRepository _incorporationMethodRepository;
+        private readonly IMapper _mapper;
 
-    public async Task<IEnumerable<IncorporationMethodDto>?> FetchAllAsync()
-    {
-        return _mapper.Map<IEnumerable<IncorporationMethodDto>>(await _incorporationMethodRepository.FetchAllAsync());
-    }
+        public IncorporationMethodService(IIncorporationMethodRepository incorporationMethodRepository, IMapper mapper)
+        {
+            _incorporationMethodRepository = incorporationMethodRepository;
+            _mapper = mapper;
+        }
 
-    public async Task<IncorporationMethodDto?> FetchByIdAsync(int id)
-    {
-        return _mapper.Map<IncorporationMethodDto>(await _incorporationMethodRepository.FetchByIdAsync(id));
+        public async Task<IEnumerable<IncorporationMethodDto>?> FetchAllAsync()
+        {
+            var methods = await _incorporationMethodRepository.FetchAllAsync();
+            return _mapper.Map<IEnumerable<IncorporationMethodDto>>(methods);
+        }
+
+        public async Task<IncorporationMethodDto?> FetchByIdAsync(int id)
+        {
+            var method = await _incorporationMethodRepository.FetchByIdAsync(id);
+            return _mapper.Map<IncorporationMethodDto>(method);
+        }
+
+        public async Task<IEnumerable<IncorporationMethodDto>?> FetchByAppMethodIdAsync(int methodId)
+        {
+            var methods = await _incorporationMethodRepository.FetchByAppMethodIdAsync(methodId);
+            return _mapper.Map<IEnumerable<IncorporationMethodDto>>(methods);
+        }
     }
 }

--- a/Manner.Api/Manner.Application/Services/ManureTypeService.cs
+++ b/Manner.Api/Manner.Application/Services/ManureTypeService.cs
@@ -1,31 +1,53 @@
-﻿using Manner.Core.Interfaces;
-using Manner.Core.Entities;
+﻿using AutoMapper;
+using Manner.Application.DTOs;
 using Manner.Application.Interfaces;
 using Manner.Core.Attributes;
+using Manner.Core.Entities;
+using Manner.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
-using Manner.Application.DTOs;
-using AutoMapper;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace Manner.Application.Services;
-
-[Service(ServiceLifetime.Transient)]
-public class ManureTypeService : IManureTypeService
+namespace Manner.Application.Services
 {
-    private readonly IManureTypeRepository _manureTypeRepository;
-    private readonly IMapper _mapper;
-    public ManureTypeService(IManureTypeRepository manureTypeRepository, IMapper mapper)
+    [Service(ServiceLifetime.Transient)]
+    public class ManureTypeService : IManureTypeService
     {
-        _manureTypeRepository = manureTypeRepository;
-        _mapper = mapper;
-    }
+        private readonly IManureTypeRepository _manureTypeRepository;
+        private readonly IMapper _mapper;
 
-    public async Task<IEnumerable<ManureTypeDto>?> FetchAllAsync()
-    {
-        return _mapper.Map<IEnumerable<ManureTypeDto>>(await _manureTypeRepository.FetchAllAsync());
-    }
+        public ManureTypeService(IManureTypeRepository manureTypeRepository, IMapper mapper)
+        {
+            _manureTypeRepository = manureTypeRepository;
+            _mapper = mapper;
+        }
 
-    public async Task<ManureTypeDto?> FetchByIdAsync(int id)
-    {
-        return _mapper.Map<ManureTypeDto>(await _manureTypeRepository.FetchByIdAsync(id));
+        public async Task<IEnumerable<ManureTypeDto>?> FetchAllAsync()
+        {
+            return _mapper.Map<IEnumerable<ManureTypeDto>>(await _manureTypeRepository.FetchAllAsync());
+        }
+
+        public async Task<ManureTypeDto?> FetchByIdAsync(int id)
+        {
+            return _mapper.Map<ManureTypeDto>(await _manureTypeRepository.FetchByIdAsync(id));
+        }
+
+        public async Task<IEnumerable<ManureTypeDto>?> FetchByCriteriaAsync(
+            int? manureGroupId = null,
+            int? manureTypeCategoryId = null,
+            int? countryId = null,
+            bool? highReadilyAvailableNitrogen = null,
+            bool? isLiquid = null)
+        {
+            var manureTypes = await _manureTypeRepository.FetchByCriteriaAsync(
+                manureGroupId,
+                manureTypeCategoryId,
+                countryId,
+                highReadilyAvailableNitrogen,
+                isLiquid
+            );
+
+            return _mapper.Map<IEnumerable<ManureTypeDto>>(manureTypes);
+        }
     }
 }

--- a/Manner.Api/Manner.Core/Entities/ApplicationMethodsIncorpMethods.cs
+++ b/Manner.Api/Manner.Core/Entities/ApplicationMethodsIncorpMethods.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Manner.Core.Entities
+{
+    public class ApplicationMethodsIncorpMethods
+    {
+        public int ApplicationMethodID { get; set; }
+        public int IncorporationMethodID { get; set; }
+
+        public ApplicationMethod ApplicationMethod { get; set; }
+        public IncorporationMethod IncorporationMethod { get; set; }
+    }
+}

--- a/Manner.Api/Manner.Core/Entities/IncorpMethodsIncorpDelays.cs
+++ b/Manner.Api/Manner.Core/Entities/IncorpMethodsIncorpDelays.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Manner.Core.Entities
+{
+    public class IncorpMethodsIncorpDelays
+    {
+        public int IncorporationMethodID { get; set; }
+        public int IncorporationDelayID { get; set; }
+
+        public IncorporationMethod IncorporationMethod { get; set; }
+        public IncorporationDelay IncorporationDelay { get; set; }
+    }
+}

--- a/Manner.Api/Manner.Core/Interfaces/IIncorporationDelayRepository.cs
+++ b/Manner.Api/Manner.Core/Interfaces/IIncorporationDelayRepository.cs
@@ -4,4 +4,5 @@ namespace Manner.Core.Interfaces;
 
 public interface IIncorporationDelayRepository : IRepository<IncorporationDelay>
 {
+    Task<IEnumerable<IncorporationDelay>?> FetchByIncorpMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Core/Interfaces/IIncorporationMethodRepository.cs
+++ b/Manner.Api/Manner.Core/Interfaces/IIncorporationMethodRepository.cs
@@ -4,4 +4,5 @@ namespace Manner.Core.Interfaces;
 
 public interface IIncorporationMethodRepository : IRepository<IncorporationMethod>
 {
+    Task<IEnumerable<IncorporationMethod>?> FetchByAppMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Core/Interfaces/IManureTypeRepository.cs
+++ b/Manner.Api/Manner.Core/Interfaces/IManureTypeRepository.cs
@@ -4,4 +4,5 @@ namespace Manner.Core.Interfaces;
 
 public interface IManureTypeRepository : IRepository<ManureType>
 {
+    Task<IEnumerable<ManureType>?> FetchByCriteriaAsync(int? manureGroupId = null, int? manureTypeCategoryId = null, int? countryId = null, bool? highReadilyAvailableNitrogen = null, bool? isLiquid = null);
 }

--- a/Manner.Api/Manner.Infrastructure/Data/ApplicationDbContext.cs
+++ b/Manner.Api/Manner.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,15 +1,10 @@
 ﻿using Manner.Core.Entities;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Manner.Infrastructure.Data
 {
     public class ApplicationDbContext : DbContext
-    {        
+    {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         {
         }
@@ -20,6 +15,12 @@ namespace Manner.Infrastructure.Data
         public DbSet<CropType> CropTypes { get; set; }
         public DbSet<IncorporationDelay> IncorporationDelays { get; set; }
         public DbSet<IncorporationMethod> IncorporationMethods { get; set; }
+
+        // Define the IncorpMethodsIncorpDelays as keyless
+        public DbSet<IncorpMethodsIncorpDelays> IncorpMethodsIncorpDelays { get; set; }
+
+        public DbSet<ApplicationMethodsIncorpMethods> ApplicationMethodsIncorpMethods { get; set; }
+
         public DbSet<ManureGroup> ManureGroups { get; set; }
         public DbSet<ManureType> ManureTypes { get; set; }
         public DbSet<ManureTypeCategory> ManureTypeCategories { get; set; }
@@ -28,5 +29,18 @@ namespace Manner.Infrastructure.Data
         public DbSet<SubSoil> SubSoils { get; set; }
         public DbSet<TopSoil> TopSoils { get; set; }
         public DbSet<Windspeed> Windspeeds { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Mark IncorpMethodsIncorpDelays as keyless
+            modelBuilder.Entity<IncorpMethodsIncorpDelays>()
+                .HasNoKey();
+
+            // Mark ApplicationMethodsIncorpMethods as keyless
+
+            modelBuilder.Entity<ApplicationMethodsIncorpMethods>()
+                .HasNoKey();
+            base.OnModelCreating(modelBuilder);
+        }
     }
 }

--- a/Manner.Api/Manner.Infrastructure/Repositories/IncorporationDelayRepository.cs
+++ b/Manner.Api/Manner.Infrastructure/Repositories/IncorporationDelayRepository.cs
@@ -24,4 +24,13 @@ public class IncorporationDelayRepository : IIncorporationDelayRepository
     {
         return await _context.IncorporationDelays.FirstOrDefaultAsync(a => a.ID == id);
     }
+
+    public async Task<IEnumerable<IncorporationDelay>?> FetchByIncorpMethodIdAsync(int methodId)
+    {
+        return await _context.IncorporationDelays
+            .Where(d => _context.Set<IncorpMethodsIncorpDelays>()
+                .Any(link => link.IncorporationMethodID == methodId && link.IncorporationDelayID == d.ID))
+            .ToListAsync();
+    }
+
 }

--- a/Manner.Api/Manner.Infrastructure/Repositories/IncorporationMethodRepository.cs
+++ b/Manner.Api/Manner.Infrastructure/Repositories/IncorporationMethodRepository.cs
@@ -4,24 +4,39 @@ using Manner.Core.Interfaces;
 using Manner.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
-namespace Manner.Infrastructure.Repositories;
-[Repository(ServiceLifetime.Scoped)]
-public class IncorporationMethodRepository : IIncorporationMethodRepository
+namespace Manner.Infrastructure.Repositories
 {
-    private readonly ApplicationDbContext _context;
-    public IncorporationMethodRepository(ApplicationDbContext applicationDbContext)
+    [Repository(ServiceLifetime.Scoped)]
+    public class IncorporationMethodRepository : IIncorporationMethodRepository
     {
-        _context = applicationDbContext;
-    }
+        private readonly ApplicationDbContext _context;
 
-    public async Task<IEnumerable<IncorporationMethod>?> FetchAllAsync()
-    {
-        return await _context.IncorporationMethods.ToListAsync();
-    }
+        public IncorporationMethodRepository(ApplicationDbContext applicationDbContext)
+        {
+            _context = applicationDbContext;
+        }
 
-    public async Task<IncorporationMethod?> FetchByIdAsync(int id)
-    {
-        return await _context.IncorporationMethods.FirstOrDefaultAsync(a => a.ID == id);
+        public async Task<IEnumerable<IncorporationMethod>?> FetchAllAsync()
+        {
+            return await _context.IncorporationMethods.ToListAsync();
+        }
+
+        public async Task<IncorporationMethod?> FetchByIdAsync(int id)
+        {
+            return await _context.IncorporationMethods.FirstOrDefaultAsync(a => a.ID == id);
+        }
+
+        public async Task<IEnumerable<IncorporationMethod>?> FetchByAppMethodIdAsync(int methodId)
+        {
+            return await _context.IncorporationMethods
+                .Where(im => _context.ApplicationMethodsIncorpMethods
+                    .Any(link => link.ApplicationMethodID == methodId && link.IncorporationMethodID == im.ID))
+                .ToListAsync();
+        }
+
     }
 }

--- a/Manner.Api/Manner.Infrastructure/Repositories/ManureTypeRepository.cs
+++ b/Manner.Api/Manner.Infrastructure/Repositories/ManureTypeRepository.cs
@@ -4,24 +4,67 @@ using Manner.Core.Interfaces;
 using Manner.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
-namespace Manner.Infrastructure.Repositories;
-[Repository(ServiceLifetime.Scoped)]
-public class ManureTypeRepository : IManureTypeRepository
+namespace Manner.Infrastructure.Repositories
 {
-    private readonly ApplicationDbContext _context;
-    public ManureTypeRepository(ApplicationDbContext applicationDbContext)
+    [Repository(ServiceLifetime.Scoped)]
+    public class ManureTypeRepository : IManureTypeRepository
     {
-        _context = applicationDbContext;
-    }
+        private readonly ApplicationDbContext _context;
 
-    public async Task<IEnumerable<ManureType>?> FetchAllAsync()
-    {
-        return await _context.ManureTypes.ToListAsync();
-    }
+        public ManureTypeRepository(ApplicationDbContext applicationDbContext)
+        {
+            _context = applicationDbContext;
+        }
 
-    public async Task<ManureType?> FetchByIdAsync(int id)
-    {
-        return await _context.ManureTypes.FirstOrDefaultAsync(a => a.ID == id);
+        public async Task<IEnumerable<ManureType>?> FetchAllAsync()
+        {
+            return await _context.ManureTypes.ToListAsync();
+        }
+
+        public async Task<ManureType?> FetchByIdAsync(int id)
+        {
+            return await _context.ManureTypes.FirstOrDefaultAsync(a => a.ID == id);
+        }
+
+        public async Task<IEnumerable<ManureType>?> FetchByCriteriaAsync(
+            int? manureGroupId = null,
+            int? manureTypeCategoryId = null,
+            int? countryId = null,
+            bool? highReadilyAvailableNitrogen = null,
+            bool? isLiquid = null)
+        {
+            IQueryable<ManureType> query = _context.ManureTypes;
+
+            if (manureGroupId.HasValue)
+            {
+                query = query.Where(mt => mt.ManureGroupID == manureGroupId.Value);
+            }
+
+            if (manureTypeCategoryId.HasValue)
+            {
+                query = query.Where(mt => mt.ManureTypeCategoryID == manureTypeCategoryId.Value);
+            }
+
+            if (countryId.HasValue)
+            {
+                query = query.Where(mt => mt.CountryID == countryId.Value);
+            }
+
+            if (highReadilyAvailableNitrogen.HasValue)
+            {
+                query = query.Where(mt => mt.HighReadilyAvailableNitrogen == highReadilyAvailableNitrogen.Value);
+            }
+
+            if (isLiquid.HasValue)
+            {
+                query = query.Where(mt => mt.IsLiquid == isLiquid.Value);
+            }
+
+            return await query.ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
# Added Endpoints for Remaining Tables

> **Note:** This branch can be removed when merged.
## 1. Updated Repository and Service Layers

- **ManureTypes**:
  - **ManureTypeRepository**:
    - Added method `FetchByCriteriaAsync(int? manureGroupId, int? manureTypeCategoryId, int? countryId, bool? highReadilyAvailableNitrogen, bool? isLiquid)` to filter manure types based on provided criteria.
  - **ManureTypeService**:
    - Added method `FetchByCriteriaAsync` to map filtered results to DTOs and return them.
  
- **IncorporationDelays**:
  - **IncorporationDelayRepository**:
    - Added method `FetchByMethodIdAsync(int methodId)` to retrieve incorporation delays based on a specific incorporation method.
  - **IncorporationDelayService**:
    - Added method `FetchByMethodIdAsync` to map results and return them as DTOs.

## 2. Added Optional Filtering to Controller

- **ManureTypesController**:
  - Implemented the `GET /api/manure-types` endpoint to:
    - Retrieve all manure types if no query parameters are provided.
    - Apply optional filters based on the following parameters:
      - `manureGroupId`
      - `manureTypeCategoryId`
      - `countryId`
      - `highReadilyAvailableNitrogen`
      - `isLiquid`
    - Return `404 NotFound` if no manure types match the criteria.
  - Added `GET /api/manure-types/{id}` to retrieve manure types by ID.

## 3. Enhanced Swagger Documentation

- Added detailed descriptions to the Swagger documentation for the `manure-types` endpoint, clarifying:
  - The optional nature of the query parameters.
  - That all manure types will be retrieved if no filters are provided.
- Used `SwaggerOperation` and `SwaggerParameter` attributes to improve clarity for API consumers.

## 4. Applied the Same Approach to Other Tables

- Implemented `FetchAll` and `FetchById` endpoints for the following tables:
  - **ManureGroups**
  - **ManureTypeCategories**
  - **MoistureTypes**
  - **RainTypes**
  - **SubSoils**
  - **TopSoils**
  - **Windspeeds**

- Ensured consistent design and implementation across all controllers.

> **Note:** This branch can be removed when merged.
