### PR TITLE
Updated SubSoil and TopSoil to include VolumetricMeasure and Availabl…

### DIFF
--- a/Manner.Api/Manner.Core/Entities/SubSoil.cs
+++ b/Manner.Api/Manner.Core/Entities/SubSoil.cs
@@ -2,5 +2,7 @@
 public class SubSoil
 {
     public int ID { get; set; }
-    public string Name { get; set; }        
+    public string Name { get; set; }
+    public int VolumetricMeasure { get; set; } // New property
+    public int AvailableWaterCapacity { get; set; } // New property
 }

--- a/Manner.Api/Manner.Core/Entities/TopSoil.cs
+++ b/Manner.Api/Manner.Core/Entities/TopSoil.cs
@@ -3,4 +3,6 @@ public class TopSoil
 {
     public int ID { get; set; }
     public string Name { get; set; }
+    public int VolumetricMeasure { get; set; } // New property
+    public int AvailableWaterCapacity { get; set; } // New property
 }

--- a/Manner.Api/Manner.Database/DBO/Tables/SubSoils.sql
+++ b/Manner.Api/Manner.Database/DBO/Tables/SubSoils.sql
@@ -2,5 +2,7 @@ CREATE TABLE [dbo].[SubSoils]
 (
 	[ID] INT IDENTITY(1,1) NOT NULL, 
     [Name] NVARCHAR(100) NOT NULL,
+    [VolumetricMeasure] INT NOT NULL, 
+    [AvailableWaterCapacity] INT NOT NULL, 
 	CONSTRAINT [PK_SubSoils] PRIMARY KEY CLUSTERED ([ID] ASC)	 
 )

--- a/Manner.Api/Manner.Database/DBO/Tables/TopSoils.sql
+++ b/Manner.Api/Manner.Database/DBO/Tables/TopSoils.sql
@@ -2,5 +2,7 @@ CREATE TABLE [dbo].[TopSoils]
 (
 	[ID] INT IDENTITY(1,1) NOT NULL, 
     [Name] NVARCHAR(100) NOT NULL,
-	CONSTRAINT [PK_TopSoils] PRIMARY KEY CLUSTERED ([ID] ASC)	 
+	[VolumetricMeasure] INT NOT NULL, 
+    [AvailableWaterCapacity] INT NOT NULL, 
+    CONSTRAINT [PK_TopSoils] PRIMARY KEY CLUSTERED ([ID] ASC)	 
 )


### PR DESCRIPTION
# Update SubSoil and TopSoil Entities and Database Schema to Include VolumetricMeasure and AvailableWaterCapacity

## Description
This pull request includes the following updates:

### 1. Database Schema Update:
- **Added Columns**:
  - `VolumetricMeasure`: Represents the volumetric measure of the soil.
  - `AvailableWaterCapacity`: Represents the available water capacity of the soil.
- **Updated Post-Deployment Script**:
  - Populated the newly added columns in the `SubSoils` and `TopSoils` tables with the correct data based on existing records.

### 2. Entity Class Updates:
- **SubSoil Entity**:
  - Added `VolumetricMeasure` property (int).
  - Added `AvailableWaterCapacity` property (int).
- **TopSoil Entity**:
  - Added `VolumetricMeasure` property (int).
  - Added `AvailableWaterCapacity` property (int).

These updates are necessary to reflect the changes in the database schema within the application layer, ensuring that the system can properly handle and store soil data with the new attributes.
