### PR TITLE
Added Additional Filters to Endpoints

### DIFF
--- a/Manner.Api/Manner.Api/Controllers/MannerController.cs
+++ b/Manner.Api/Manner.Api/Controllers/MannerController.cs
@@ -82,19 +82,35 @@ public class MannerController : ControllerBase
     }
 
     [HttpGet("application-methods")]
-    [SwaggerOperation(Summary = "Retrieve all application methods", Description = "Fetches a list of all application methods available.")]
+    [SwaggerOperation(
+        Summary = "Retrieve all application methods or filter by criteria",
+        Description = "Fetches all application methods if no filters are provided. You can filter by optional parameters such as isLiquid and fieldType."
+    )]
     [ProducesResponseType(typeof(StandardResponse), 200)]
+    [ProducesResponseType(404)]
     [ProducesResponseType(500)]
-    public async Task<ActionResult<StandardResponse>> ApplicationMethods()
+    public async Task<ActionResult<StandardResponse>> ApplicationMethods(
+        [FromQuery, SwaggerParameter("Whether to filter by liquid application methods (true/false)", Required = false)] bool? isLiquid = null,
+        [FromQuery, SwaggerParameter("The type of field to filter by (1 = arable, 2 = grass)", Required = false)] int? fieldType = null)
     {
-        var data = await _applicationMethodService.FetchAllAsync();
-        return Ok(new StandardResponse
+        IEnumerable<ApplicationMethodDto>? applicationMethods;
+
+        if (!isLiquid.HasValue && !fieldType.HasValue)
         {
-            Success = data != null && data.Any(),
-            Data = data,
-            Message = data != null && data.Any() ? null : "No application methods found."
-        });
+            // No filter provided, return all application methods
+            applicationMethods = await _applicationMethodService.FetchAllAsync();
+        }
+        else
+        {
+            // Filters applied
+            applicationMethods = await _applicationMethodService.FetchByCriteriaAsync(isLiquid, fieldType);
+        }
+
+        return applicationMethods != null && applicationMethods.Any()
+            ? Ok(new StandardResponse { Success = true, Data = applicationMethods })
+            : NotFound(new StandardResponse { Success = false, Message = "No application methods found matching the specified criteria." });
     }
+
 
     [HttpGet("application-methods/{id}")]
     [SwaggerOperation(Summary = "Retrieve application method by ID", Description = "Fetches a specific application method by its unique ID.")]
@@ -219,6 +235,22 @@ public class MannerController : ControllerBase
             ? Ok(new StandardResponse { Success = true, Data = delays })
             : NotFound(new StandardResponse { Success = false, Message = "No incorporation delays found for the given method ID." });
     }
+
+    [HttpGet("incorporation-delays/by-applicable-for")]
+    [SwaggerOperation(Summary = "Retrieve incorporation delays by ApplicableFor", Description = "Fetches incorporation delays based on whether they apply to Liquid, Solid, Poultry, or All.")]
+    [ProducesResponseType(typeof(StandardResponse), 200)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(500)]
+    public async Task<ActionResult<StandardResponse>> IncorporationDelaysByApplicableFor(
+    [FromQuery, SwaggerParameter("Filter by ApplicableFor (L for Liquid, S for Solid, P for Poultry, NULL for N/A or Not Incorporated)", Required = true)] string applicableFor)
+    {
+        var delays = await _incorporationDelayService.FetchByApplicableForAsync(applicableFor);
+
+        return delays != null && delays.Any()
+            ? Ok(new StandardResponse { Success = true, Data = delays })
+            : NotFound(new StandardResponse { Success = false, Message = "No incorporation delays found for the specified filter." });
+    }
+
 
     [HttpGet("incorporation-methods")]
     [SwaggerOperation(Summary = "Retrieve all incorporation methods", Description = "Fetches a list of all incorporation methods available.")]

--- a/Manner.Api/Manner.Api/Manner.Api.csproj
+++ b/Manner.Api/Manner.Api/Manner.Api.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Manner.Application\Manner.Application.csproj" />
     <ProjectReference Include="..\Manner.Infrastructure.Configuration\Manner.Infrastructure.Configuration.csproj" />
+    <ProjectReference Include="..\Manner.Infrastructure\Manner.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Manner.Api/Manner.Application/Interfaces/IApplicationMethodService.cs
+++ b/Manner.Api/Manner.Application/Interfaces/IApplicationMethodService.cs
@@ -8,5 +8,6 @@ using System.Threading.Tasks;
 
 namespace Manner.Application.Interfaces;
 public interface IApplicationMethodService : IService<ApplicationMethodDto>
-{   
+{
+    Task<IEnumerable<ApplicationMethodDto>?> FetchByCriteriaAsync(bool? isLiquid = null, int? fieldType = null);
 }

--- a/Manner.Api/Manner.Application/Interfaces/IIncorporationDelayService.cs
+++ b/Manner.Api/Manner.Application/Interfaces/IIncorporationDelayService.cs
@@ -4,5 +4,6 @@ namespace Manner.Application.Interfaces;
 
 public interface IIncorporationDelayService : IService<IncorporationDelayDto>
 {
+    Task<IEnumerable<IncorporationDelayDto>?> FetchByApplicableForAsync(string applicableFor);
     Task<IEnumerable<IncorporationDelayDto>?> FetchByIncorpMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Application/Services/ApplicationMethodService.cs
+++ b/Manner.Api/Manner.Application/Services/ApplicationMethodService.cs
@@ -27,4 +27,10 @@ public class ApplicationMethodService : IApplicationMethodService
     {
         return _mapper.Map<ApplicationMethodDto>(await _applicationMethodRepository.FetchByIdAsync(id));
     }
+
+    public async Task<IEnumerable<ApplicationMethodDto>?> FetchByCriteriaAsync(bool? isLiquid = null, int? fieldType = null)
+    {
+        var methods = await _applicationMethodRepository.FetchByCriteriaAsync(isLiquid, fieldType);
+        return _mapper.Map<IEnumerable<ApplicationMethodDto>>(methods);
+    }
 }

--- a/Manner.Api/Manner.Application/Services/IncorporationDelayService.cs
+++ b/Manner.Api/Manner.Application/Services/IncorporationDelayService.cs
@@ -34,4 +34,11 @@ public class IncorporationDelayService : IIncorporationDelayService
         var delays = await _incorporationDelayRepository.FetchByIncorpMethodIdAsync(methodId);
         return _mapper.Map<IEnumerable<IncorporationDelayDto>>(delays);
     }
+
+    public async Task<IEnumerable<IncorporationDelayDto>?> FetchByApplicableForAsync(string applicableFor)
+    {
+        var delays = await _incorporationDelayRepository.FetchByApplicableForAsync(applicableFor);
+        return _mapper.Map<IEnumerable<IncorporationDelayDto>>(delays);
+    }
+
 }

--- a/Manner.Api/Manner.Core/Interfaces/IApplicationMethodRepository.cs
+++ b/Manner.Api/Manner.Core/Interfaces/IApplicationMethodRepository.cs
@@ -7,5 +7,6 @@ using System.Threading.Tasks;
 
 namespace Manner.Core.Interfaces;
 public interface IApplicationMethodRepository : IRepository<ApplicationMethod>
-{   
+{
+    Task<IEnumerable<ApplicationMethod>?> FetchByCriteriaAsync(bool? isLiquid = null, int? fieldType = null);
 }

--- a/Manner.Api/Manner.Core/Interfaces/IIncorporationDelayRepository.cs
+++ b/Manner.Api/Manner.Core/Interfaces/IIncorporationDelayRepository.cs
@@ -4,5 +4,8 @@ namespace Manner.Core.Interfaces;
 
 public interface IIncorporationDelayRepository : IRepository<IncorporationDelay>
 {
+    Task<IEnumerable<IncorporationDelay>?> FetchAllAsync();
+    Task<IEnumerable<IncorporationDelay>?> FetchByApplicableForAsync(string applicableFor);
+    Task<IncorporationDelay?> FetchByIdAsync(int id);
     Task<IEnumerable<IncorporationDelay>?> FetchByIncorpMethodIdAsync(int methodId);
 }

--- a/Manner.Api/Manner.Infrastructure/Repositories/ApplicationMethodRepository.cs
+++ b/Manner.Api/Manner.Infrastructure/Repositories/ApplicationMethodRepository.cs
@@ -24,4 +24,54 @@ public class ApplicationMethodRepository : IApplicationMethodRepository
     {
         return await _context.ApplicationMethods.FirstOrDefaultAsync(a => a.ID == id);
     }
+
+    public async Task<IEnumerable<ApplicationMethod>?> FetchByCriteriaAsync(bool? isLiquid = null, int? fieldType = null)
+    {
+        IQueryable<ApplicationMethod> query = _context.ApplicationMethods;
+
+        // Determine field based on fieldType: 1 = arable, 2 = grass
+        string? applicableField = fieldType switch
+        {
+            1 => nameof(ApplicationMethod.ApplicableForArableAndHorticulture),
+            2 => nameof(ApplicationMethod.ApplicableForGrass),
+            _ => null
+        };
+
+        if (isLiquid.HasValue)
+        {
+            string liquidCondition = isLiquid.Value ? "L" : "B";
+
+            if (applicableField != null)
+            {
+                // Exclude null values in the applicable field when filtering by fieldType
+                query = query.Where(a => EF.Property<string>(a, applicableField) != null &&
+                                         (EF.Property<string>(a, applicableField) == "B" ||
+                                          EF.Property<string>(a, applicableField) == liquidCondition));
+            }
+            else
+            {
+                if (isLiquid.Value)
+                {
+                    query = query.Where(a => (a.ApplicableForArableAndHorticulture == "B" || a.ApplicableForArableAndHorticulture == "L") ||
+                                             (a.ApplicableForGrass == "B" || a.ApplicableForGrass == "L"));
+                }
+                else
+                {
+                    query = query.Where(a => a.ApplicableForArableAndHorticulture == "B" || a.ApplicableForGrass == "B");
+                }
+            }
+        }
+        else if (applicableField != null)
+        {
+            // Apply fieldType-specific filtering and exclude null values
+            query = query.Where(a => EF.Property<string>(a, applicableField) != null &&
+                                     (EF.Property<string>(a, applicableField) == "B" ||
+                                      EF.Property<string>(a, applicableField) == "L"));
+        }
+
+        return await query.ToListAsync();
+    }
+
+
+
 }

--- a/Manner.Api/Manner.Infrastructure/Repositories/IncorporationDelayRepository.cs
+++ b/Manner.Api/Manner.Infrastructure/Repositories/IncorporationDelayRepository.cs
@@ -33,4 +33,21 @@ public class IncorporationDelayRepository : IIncorporationDelayRepository
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<IncorporationDelay>?> FetchByApplicableForAsync(string applicableFor)
+    {
+        // Fetch delays where ApplicableFor is 'A' (All) or matches the specified filter
+        if (applicableFor == "NULL")
+        {
+            // Handle special case for NULL values in the ApplicableFor column
+            return await _context.IncorporationDelays
+                .Where(d => d.ApplicableFor == null)
+                .ToListAsync();
+        }
+
+        return await _context.IncorporationDelays
+            .Where(d => d.ApplicableFor == "A" || d.ApplicableFor == applicableFor)
+            .ToListAsync();
+    }
+
+
 }

--- a/Manner.Api/Manner.Tests/Manner.Tests.csproj
+++ b/Manner.Api/Manner.Tests/Manner.Tests.csproj
@@ -15,6 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
@@ -25,7 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Manner.Api\Manner.Api.csproj" />
     <ProjectReference Include="..\Manner.Application\Manner.Application.csproj" />
+    <ProjectReference Include="..\Manner.Core\Manner.Core.csproj" />
+    <ProjectReference Include="..\Manner.Infrastructure\Manner.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Manner.Api/Manner.Tests/Repositories/ApplicationMethodRepoTests.cs
+++ b/Manner.Api/Manner.Tests/Repositories/ApplicationMethodRepoTests.cs
@@ -1,0 +1,188 @@
+﻿using FluentAssertions;
+using Manner.Core.Entities;
+using Manner.Infrastructure.Data;
+using Manner.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Manner.Tests.Repositories;
+
+public class ApplicationMethodRepositoryTests
+{
+    private readonly ApplicationMethodRepository _repository;
+    private readonly ApplicationDbContext _context;
+
+    public ApplicationMethodRepositoryTests()
+    {
+        // Set up the in-memory database
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "ApplicationMethodsTestDb")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+
+        // Seed data
+        SeedData(_context);
+
+        _repository = new ApplicationMethodRepository(_context);
+    }
+
+    private void SeedData(ApplicationDbContext context)
+    {
+        var methods = new List<ApplicationMethod>
+        {
+            new ApplicationMethod { Name = "Method 1", ApplicableForGrass = "L", ApplicableForArableAndHorticulture = "B" },  // Liquid for Grass, Both for Arable
+            new ApplicationMethod { Name = "Broadcast spreader", ApplicableForGrass = "B", ApplicableForArableAndHorticulture = "B" },  // Both for both fields
+            new ApplicationMethod { Name = "Method 3", ApplicableForGrass = "B", ApplicableForArableAndHorticulture = null },  // Both for Grass, not applicable for Arable
+            new ApplicationMethod { Name = "Method 4", ApplicableForGrass = null, ApplicableForArableAndHorticulture = "B" },  // Both for Arable, not applicable for Grass
+            new ApplicationMethod { Name = "Liquid Arable", ApplicableForGrass = null, ApplicableForArableAndHorticulture = "L" },  // Liquid for Arable only
+            new ApplicationMethod { Name = "Liquid Grass", ApplicableForGrass = "L", ApplicableForArableAndHorticulture = null },  // Liquid for Grass only
+        };
+
+        context.ApplicationMethods.RemoveRange(context.ApplicationMethods);
+        context.SaveChanges();
+
+        context.ApplicationMethods.AddRange(methods);
+        context.SaveChanges();
+    }
+
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnAllMethods_WhenIsLiquidIsTrue()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(6);  // All methods have either 'B' or 'L' in one of the fields, so all are returned
+    }
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnMethodsWithBInEitherColumn_WhenIsLiquidIsFalse()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4);  // Only methods with 'B' in either column: Method 1, Broadcast spreader, Method 3, Method 4
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 3", "Method 4" });
+    }
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnMethodsWithBOrLInArable_WhenFieldTypeIsArable()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(fieldType: 1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4);  // Methods with 'B' or 'L' in the Arable column: Method 1, Broadcast spreader, Method 4, Liquid Arable
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 4", "Liquid Arable" });
+    }
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnMethodsWithBOrLInGrass_WhenFieldTypeIsGrass()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(fieldType: 2);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4);  // Methods with 'B' or 'L' in the Grass column: Method 1, Broadcast spreader, Method 3, Liquid Grass
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 3", "Liquid Grass" });
+    }
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnArableLiquidMethods_WhenIsLiquidIsTrueAndFieldTypeIsArable()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: true, fieldType: 1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4);  // Methods with 'B' or 'L' in the Arable field: Method 1, Broadcast spreader, Method 4, Liquid Arable
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 4", "Liquid Arable" });
+    }
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnGrassLiquidMethods_WhenIsLiquidIsTrueAndFieldTypeIsGrass()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: true, fieldType: 2);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(4);  // Methods with 'B' or 'L' in the Grass field: Method 1, Broadcast spreader, Method 3, Liquid Grass
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 3", "Liquid Grass" });
+    }
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnNonLiquidArableMethods_WhenIsLiquidIsFalseAndFieldTypeIsArable()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: false, fieldType: 1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(3);  // Only methods with 'B' in the Arable field: Method 1, Broadcast spreader, Method 4
+        result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader", "Method 4" });
+    }
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnNonLiquidGrassMethods_WhenIsLiquidIsFalseAndFieldTypeIsGrass()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(isLiquid: false, fieldType: 2);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2);  // Only methods with 'B' in the Grass field: Broadcast spreader, Method 3
+        result.Select(r => r.Name).Should().Contain(new[] { "Broadcast spreader", "Method 3" });
+    }
+
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnNoMethods_WhenNoDataExists()
+    {
+        // Clear all data from the database
+        _context.ApplicationMethods.RemoveRange(_context.ApplicationMethods);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FetchByCriteriaAsync();
+
+        // Assert
+        result.Should().BeEmpty();  // Expect no methods returned
+    }
+
+    [Fact]
+    public async Task FetchByCriteriaAsync_ShouldReturnAllMethods_WhenInvalidFieldTypeIsProvided()
+    {
+        // Act
+        var result = await _repository.FetchByCriteriaAsync(fieldType: 999);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(6);  // Invalid fieldType should return all methods since no filtering is applied
+    }
+
+
+
+
+    // Tear down in-memory database after each test
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+}

--- a/Manner.Api/Manner.Tests/Services/ApplicationMethodServiceTests.cs
+++ b/Manner.Api/Manner.Tests/Services/ApplicationMethodServiceTests.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Manner.Application.DTOs;
+using Manner.Application.Interfaces;
+using Manner.Application.Services;
+using Manner.Core.Entities;
+using Manner.Core.Interfaces;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Manner.Tests.Services
+{
+    public class ApplicationMethodServiceTests
+    {
+        private readonly Mock<IApplicationMethodRepository> _mockRepository;
+        private readonly Mock<IMapper> _mockMapper;
+        private readonly IApplicationMethodService _service;
+
+        public ApplicationMethodServiceTests()
+        {
+            // Mock the repository and the mapper
+            _mockRepository = new Mock<IApplicationMethodRepository>();
+            _mockMapper = new Mock<IMapper>();
+
+            // Create the service with mocked dependencies
+            _service = new ApplicationMethodService(_mockRepository.Object, _mockMapper.Object);
+        }
+
+        // Test FetchAllAsync()
+        [Fact]
+        public async Task FetchAllAsync_ShouldReturnAllMethods_WhenMethodsExist()
+        {
+            // Arrange
+            var methods = GetSampleApplicationMethods();
+            var mappedMethods = GetSampleApplicationMethodDtos();
+
+            _mockRepository.Setup(repo => repo.FetchAllAsync())
+                .ReturnsAsync(methods);
+            _mockMapper.Setup(m => m.Map<IEnumerable<ApplicationMethodDto>>(methods))
+                .Returns(mappedMethods);
+
+            // Act
+            var result = await _service.FetchAllAsync();
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().HaveCount(2); // Expect 2 methods
+            result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader" });
+        }
+
+        // Test FetchByIdAsync()
+        [Fact]
+        public async Task FetchByIdAsync_ShouldReturnMethod_WhenMethodExists()
+        {
+            // Arrange
+            var method = new ApplicationMethod { ID = 1, Name = "Method 1" };
+            var mappedMethod = new ApplicationMethodDto { ID = 1, Name = "Method 1" };
+
+            _mockRepository.Setup(repo => repo.FetchByIdAsync(1))
+                .ReturnsAsync(method);
+            _mockMapper.Setup(m => m.Map<ApplicationMethodDto>(method))
+                .Returns(mappedMethod);
+
+            // Act
+            var result = await _service.FetchByIdAsync(1);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.ID.Should().Be(1);
+            result.Name.Should().Be("Method 1");
+        }
+
+        // Test FetchByCriteriaAsync()
+        [Fact]
+        public async Task FetchByCriteriaAsync_ShouldReturnMethods_WhenCriteriaIsSpecified()
+        {
+            // Arrange
+            var methods = GetSampleApplicationMethods();
+            var mappedMethods = GetSampleApplicationMethodDtos();
+
+            _mockRepository.Setup(repo => repo.FetchByCriteriaAsync(It.IsAny<bool?>(), It.IsAny<int?>()))
+                .ReturnsAsync(methods);
+            _mockMapper.Setup(m => m.Map<IEnumerable<ApplicationMethodDto>>(methods))
+                .Returns(mappedMethods);
+
+            // Act
+            var result = await _service.FetchByCriteriaAsync(isLiquid: true, fieldType: 1);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().HaveCount(2); // Expect 2 methods
+            result.Select(r => r.Name).Should().Contain(new[] { "Method 1", "Broadcast spreader" });
+        }
+
+        // Helper method to get sample application methods
+        private IEnumerable<ApplicationMethod> GetSampleApplicationMethods()
+        {
+            return new List<ApplicationMethod>
+            {
+                new ApplicationMethod { ID = 1, Name = "Method 1", ApplicableForGrass = "L", ApplicableForArableAndHorticulture = "B" },
+                new ApplicationMethod { ID = 2, Name = "Broadcast spreader", ApplicableForGrass = "B", ApplicableForArableAndHorticulture = "B" }
+            };
+        }
+
+        // Helper method to get sample application method DTOs
+        private IEnumerable<ApplicationMethodDto> GetSampleApplicationMethodDtos()
+        {
+            return new List<ApplicationMethodDto>
+            {
+                new ApplicationMethodDto { ID = 1, Name = "Method 1", ApplicableForGrass = "L", ApplicableForArableAndHorticulture = "B" },
+                new ApplicationMethodDto { ID = 2, Name = "Broadcast spreader", ApplicableForGrass = "B", ApplicableForArableAndHorticulture = "B" }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request: Addition of Filtering on Application Methods and Incorporation Delays + Post Deployment Script Update for Soil Types

#### Summary

This PR introduces the following changes:
- Added filtering functionality for `ApplicationMethods` and `IncorporationDelays`.
- Enhanced repositories, services, and controllers to support filtering.
- Updated the post-deployment script to include **all soil types**, aligning with the previous Manner configuration.

---

### Changes

#### 1. **Application Methods Filtering**
- **Repository Changes**: Updated `ApplicationMethodRepository` to include filtering based on `isLiquid` and `fieldType` as optional parameters. This allows fetching application methods based on these criteria.
- **Service Changes**: The service layer now calls the repository's new filtering method. The results are mapped to DTOs and returned accordingly.
- **Controller Changes**: The `ApplicationMethodController` now supports filtering via query parameters (`isLiquid` and `fieldType`). If no filters are provided, all methods are returned, but when filters are applied, the appropriate filtered results are returned.

#### 2. **Incorporation Delays Filtering**
- **Repository Changes**: Updated `IncorporationDelayRepository` to support filtering by `ApplicableFor` field. This includes handling special cases like `NULL` and other values (S, L, P).
- **Service Changes**: The service layer was updated to call the new repository filtering logic and return the appropriate DTOs.
- **Controller Changes**: The `IncorporationDelayController` now supports filtering based on `ApplicableFor`. The filtering behavior includes:
  - Returning `A` (All) + the specified `ApplicableFor` value.
  - Special handling for `NULL` values.

#### 3. **Post Deployment Script Update**
- The post-deployment script has been updated to insert all missing soil types into the `TopSoils` and `SubSoils` tables. This aligns the current soil data with the previously used Manner data structure.
  - Added soil types: Sand, Fine sandy loam, Sandy silt loam, Silty clay loam, Sandy clay, Silty clay, Chalk, Rock (not chalk).

---

### Testing

- **Only ApplicationMethod was tested** so far:
  - Unit tests were added for the new filtering logic in `ApplicationMethodRepository`.
  - Service layer tests were written to cover new filtering functionality for Application Methods.
  - Endpoint tests for Application Methods were also added.

---

### Notes
- The refactor to split the controller into multiple smaller controllers has not been done in this PR and is planned for a future refactor.
- Testing for `IncorporationDelays` filtering and other areas is pending.
